### PR TITLE
Build: Keep our internal dependencies entirely internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,8 @@ shadowJar {
     relocate("gg.essential.vigilance", "your.package.vigilance")
     // vigilance dependencies
     relocate("gg.essential.elementa", "your.package.elementa")
-    relocate("org.electronwill.nightconfig", "your.package.nightconfig")
     // elementa dependencies
     relocate("gg.essential.universalcraft", "your.package.universalcraft")
-    relocate("org.dom4j", "your.package.dom4j")
-    relocate("org.commonmark", "your.package.commonmark")
 }
 tasks.named("reobfJar").configure { dependsOn(tasks.named("shadowJar")) }
 ```
@@ -175,11 +172,8 @@ tasks.shadowJar {
     relocate("gg.essential.vigilance", "your.package.vigilance")
     // vigilance dependencies
     relocate("gg.essential.elementa", "your.package.elementa")
-    relocate("org.electronwill.nightconfig", "your.package.nightconfig")
     // elementa dependencies
     relocate("gg.essential.universalcraft", "your.package.universalcraft")
-    relocate("org.dom4j", "your.package.dom4j")
-    relocate("org.commonmark", "your.package.commonmark")
 }
 tasks.reobfJar { dependsOn(tasks.shadowJar) }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,17 @@ java.withSourcesJar()
 tasks.compileKotlin.setJvmDefault(if (platform.mcVersion >= 11400) "all" else "all-compatibility")
 loom.noServerRunConfigs()
 
+val internal = makeConfigurationForInternalDependencies {
+    relocate("com.electronwill.nightconfig", "gg.essential.vigilance.impl.nightconfig")
+    remapStringsIn("com.electronwill.nightconfig.core.file.FormatDetector")
+}
+
 dependencies {
-    implementation("com.electronwill.night-config:toml:3.6.0")
+    internal("com.electronwill.night-config:toml:3.6.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 
-    modApi("gg.essential:elementa-$platform:428") {
+    modApi("gg.essential:elementa-$platform:451") {
         exclude(module = "kotlin-reflect")
         exclude(module = "kotlin-stdlib-jdk8")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.1.1"
+        val egtVersion = "0.1.3"
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion
     }

--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -1,9 +1,9 @@
 package gg.essential.vigilance
 
-import com.electronwill.nightconfig.core.file.FileConfig
 import gg.essential.universal.UChat
 import gg.essential.vigilance.data.*
 import gg.essential.vigilance.gui.SettingsGui
+import gg.essential.vigilance.impl.nightconfig.core.file.FileConfig
 import net.minecraft.client.resources.I18n
 import java.awt.Color
 import java.io.File


### PR DESCRIPTION
By relocating and bundling them ourselves. This way no consumer has to care
about our internal dependencies (and can't accidentally forget about them) and
Fabric users do not need to JiJ additional non-mod libraries to use
Vigilance (only Vigilance, Elementa and UniversalCraft).

Requires https://github.com/EssentialGG/Elementa/pull/55 to be merged first (otherwise we indirectly expose the old Elementa's internal dependencies).