### PR TITLE
Kotlin DSL: Add protectedText property to text method

### DIFF
--- a/api/Vigilance.api
+++ b/api/Vigilance.api
@@ -88,7 +88,7 @@ public final class gg/essential/vigilance/Vigilant$CategoryPropertyBuilder {
 	public final fun subcategory (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun switch (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun switch$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public final fun text (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
+	public final synthetic fun text (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
 	public final fun text (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun text$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun text$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/api/Vigilance.api
+++ b/api/Vigilance.api
@@ -89,7 +89,9 @@ public final class gg/essential/vigilance/Vigilant$CategoryPropertyBuilder {
 	public final fun switch (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun switch$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun text (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
+	public final fun text (Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun text$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun text$default (Lgg/essential/vigilance/Vigilant$CategoryPropertyBuilder;Lkotlin/reflect/KMutableProperty0;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract class gg/essential/vigilance/data/CallablePropertyValue : gg/essential/vigilance/data/PropertyValue {

--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -419,6 +419,7 @@ abstract class Vigilant @JvmOverloads constructor(
             options: List<String> = listOf(),
             allowAlpha: Boolean = true,
             placeholder: String = "",
+            protectedText: Boolean = false,
             triggerActionOnInitialization: Boolean = true,
             hidden: Boolean = false,
             action: ((T) -> Unit)? = null,
@@ -440,6 +441,7 @@ abstract class Vigilant @JvmOverloads constructor(
                     options = options,
                     allowAlpha = allowAlpha,
                     placeholder = placeholder,
+                    protected = protectedText,
                     triggerActionOnInitialization = triggerActionOnInitialization,
                     hidden = hidden,
                     customPropertyInfo = customPropertyInfo.java,
@@ -470,6 +472,7 @@ abstract class Vigilant @JvmOverloads constructor(
             options: List<String> = listOf(),
             allowAlpha: Boolean = true,
             placeholder: String = "",
+            protectedText: Boolean = false,
             triggerActionOnInitialization: Boolean = true,
             hidden: Boolean = false,
             action: ((T) -> Unit)? = null,
@@ -489,6 +492,7 @@ abstract class Vigilant @JvmOverloads constructor(
                 options = options,
                 allowAlpha = allowAlpha,
                 placeholder = placeholder,
+                protectedText = protectedText,
                 triggerActionOnInitialization = triggerActionOnInitialization,
                 hidden = hidden,
                 action = action,
@@ -542,13 +546,25 @@ abstract class Vigilant @JvmOverloads constructor(
             triggerActionOnInitialization: Boolean = true,
             hidden: Boolean = false,
             action: ((String) -> Unit)? = null
+        ) = text(field = field, name = name, description = description, placeholder = placeholder, triggerActionOnInitialization = triggerActionOnInitialization, hidden = hidden, protectedText = false, action = action)
+
+        fun text(
+            field: KMutableProperty0<String>,
+            name: String = field.name,
+            description: String = "",
+            placeholder: String = "",
+            triggerActionOnInitialization: Boolean = true,
+            hidden: Boolean = false,
+            protectedText: Boolean = false,
+            action: ((String) -> Unit)? = null
         ) {
-            property(
-                field,
-                PropertyType.TEXT,
-                name,
-                description,
+            makeProperty(
+                field = field,
+                type = PropertyType.TEXT,
+                name = name,
+                description = description,
                 placeholder = placeholder,
+                protectedText = protectedText,
                 triggerActionOnInitialization = triggerActionOnInitialization,
                 hidden = hidden,
                 action = action

--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -538,6 +538,7 @@ abstract class Vigilant @JvmOverloads constructor(
             )
         }
 
+        @Deprecated("", level = DeprecationLevel.HIDDEN)
         fun text(
             field: KMutableProperty0<String>,
             name: String = field.name,


### PR DESCRIPTION
Adds a `protectedText` property to the Vigilant DSL's `text` method while retaining a method with the original signature for compatibility.

New usage:
```kotlin
fun text(
  field: KMutableProperty0<String>,
  name: String = field.name,
  description: String = "",
  placeholder: String = "",
  triggerActionOnInitialization: Boolean = true,
  hidden: Boolean = false,
  protectedText: Boolean = false, // new parameter added
  action: ((String) -> Unit)? = null
)
```

The `property` method remains unchanged because I have modified the `makeProperty` method, which doesn't have to be binary compatible.