### PR TITLE
Dsl: Fix searchTags being ignored

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -442,11 +442,12 @@ abstract class Vigilant @JvmOverloads constructor(
                     placeholder = placeholder,
                     triggerActionOnInitialization = triggerActionOnInitialization,
                     hidden = hidden,
+                    searchTags = searchTags,
                     customPropertyInfo = customPropertyInfo.java,
                 ),
                 value,
                 instance
-            ).also { it.attributesExt.searchTags.toMutableList().addAll(searchTags) }
+            )
 
             if (action != null) {
                 data.action = { action(it as T) }


### PR DESCRIPTION
Cause that's not how `toMutableList` works.