### PR TITLE
remove StencilEffect#enableStencil call from Vigilance#initialize

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/Vigilance.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilance.kt
@@ -2,7 +2,6 @@ package gg.essential.vigilance
 
 object Vigilance {
     @JvmStatic
-    fun initialize() {
-        // this method no longer serves any purpose but must be kept for api compatibility
-    }
+    @Deprecated("It is no longer necessary to call this method.")
+    fun initialize() {}
 }

--- a/src/main/kotlin/gg/essential/vigilance/Vigilance.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilance.kt
@@ -1,16 +1,8 @@
 package gg.essential.vigilance
 
-import gg.essential.elementa.effects.StencilEffect
-
 object Vigilance {
-    private var initialized = false
-
     @JvmStatic
     fun initialize() {
-        if (initialized)
-            return
-
-        initialized = true
-        StencilEffect.enableStencil()
+        // this method no longer serves any purpose but must be kept for api compatibility
     }
 }

--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -46,7 +46,6 @@ abstract class Vigilant @JvmOverloads constructor(
      * Initialise your config.
      */
     fun initialize() {
-        Vigilance.initialize()
         loadData()
     }
 

--- a/versions/src/main/java/gg/essential/vigilance/example/ExampleMod.java
+++ b/versions/src/main/java/gg/essential/vigilance/example/ExampleMod.java
@@ -67,9 +67,7 @@ public class ExampleMod {
     //#endif
 
     private void init() {
-        Vigilance.initialize();
         ExampleConfig.INSTANCE.preload();
-        StencilEffect.enableStencil();
     }
 
     private void tick() {


### PR DESCRIPTION
This fixes errors in cases where Vigilance#initialize is called from a thread that is not the main thread.