### PR TITLE
fix: add the ability to register multiple listeners for a property

### DIFF
--- a/api/Vigilance.api
+++ b/api/Vigilance.api
@@ -286,6 +286,7 @@ public final class gg/essential/vigilance/data/PropertyData {
 	public static final field Companion Lgg/essential/vigilance/data/PropertyData$Companion;
 	public fun <init> (Lgg/essential/vigilance/data/PropertyAttributes;Lgg/essential/vigilance/data/PropertyValue;Lgg/essential/vigilance/Vigilant;)V
 	public fun <init> (Lgg/essential/vigilance/data/PropertyAttributesExt;Lgg/essential/vigilance/data/PropertyValue;Lgg/essential/vigilance/Vigilant;)V
+	public final fun addAction (Lkotlin/jvm/functions/Function1;)V
 	public final fun component1 ()Lgg/essential/vigilance/data/PropertyAttributes;
 	public final fun component2 ()Lgg/essential/vigilance/data/PropertyValue;
 	public final fun component3 ()Lgg/essential/vigilance/Vigilant;

--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -103,14 +103,14 @@ abstract class Vigilant @JvmOverloads constructor(
         propertyCollector
             .getProperties()
             .firstOrNull { it.value is FieldBackedPropertyValue && it.value.field == field }!!
-            .action = { obj -> listener.accept(obj as T) }
+            .addAction { obj -> listener.accept(obj as T) }
     }
 
     @Suppress("UNCHECKED_CAST")
     fun <T> registerListener(propertyName: String, listener: Consumer<T>) {
         propertyCollector.getProperties()
             .firstOrNull { it.value is FieldBackedPropertyValue && it.value.field.name == propertyName }!!
-            .action = { obj -> listener.accept(obj as T) }
+            .addAction { obj -> listener.accept(obj as T) }
     }
 
     @Deprecated(
@@ -452,7 +452,7 @@ abstract class Vigilant @JvmOverloads constructor(
             )
 
             if (action != null) {
-                data.action = { action(it as T) }
+                data.addAction { action(it as T) }
             }
 
             properties.add(data)

--- a/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
@@ -15,7 +15,20 @@ data class PropertyData(@Deprecated("Replace with attributesExt", ReplaceWith("a
 
     var attributesExt: PropertyAttributesExt = PropertyAttributesExt(attributes)
         private set
+
+    @Deprecated("Replace with addAction", ReplaceWith("addAction"))
     var action: ((Any?) -> Unit)? = null
+        set(value) {
+            if (value != null) {
+                actions.add(value)
+            } else {
+                actions.remove(field)
+            }
+
+            field = value
+        }
+
+    private val actions = mutableListOf<(Any?) -> Unit>()
     var dependsOn: PropertyData? = null
     var hasDependants: Boolean = false
 
@@ -40,7 +53,7 @@ data class PropertyData(@Deprecated("Replace with attributesExt", ReplaceWith("a
         }
 
         if (attributesExt.triggerActionOnInitialization || this.value.initialized)
-            action?.invoke(value)
+            actions.forEach { it.invoke(value) }
 
         this.value.initialized = true
         this.value.setValue(value, instance)
@@ -48,8 +61,12 @@ data class PropertyData(@Deprecated("Replace with attributesExt", ReplaceWith("a
         instance.markDirty()
     }
 
+    fun addAction(action: (Any?) -> Unit) {
+        actions.add(action)
+    }
+
     fun setCallbackConsumer(callback: Consumer<Any?>) {
-        this.action = callback::accept
+        this.actions.add(callback::accept)
     }
 
     companion object {


### PR DESCRIPTION
This adds the ability to add multiple property listeners. Before, we only allowed one `action`, but this PR allows us to have multiple `action`s without breaking API changes.

Reviews are welcome, and if we should do it differently, I'd be open to suggestions on how to improve this.