### PR TITLE
fix: Mark label as selected when programatically calling `selectCategory()`

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/gui/CategoryLabel.kt
+++ b/src/main/kotlin/gg/essential/vigilance/gui/CategoryLabel.kt
@@ -11,7 +11,7 @@ import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.gui.elementa.GuiScaleOffsetConstraint
 import gg.essential.vigilance.utils.onLeftClick
 
-class CategoryLabel(private val gui: SettingsGui, private val category: Category) : UIContainer() {
+class CategoryLabel(private val gui: SettingsGui, internal val category: Category) : UIContainer() {
 
     private val text by UIText(category.name).constrain {
         y = CenterConstraint()

--- a/src/main/kotlin/gg/essential/vigilance/gui/CategoryLabel.kt
+++ b/src/main/kotlin/gg/essential/vigilance/gui/CategoryLabel.kt
@@ -54,17 +54,19 @@ class CategoryLabel(private val gui: SettingsGui, internal val category: Categor
 
     fun select() {
         gui.selectCategory(category)
-
-        isSelected = true
-        text.animate {
-            setColorAnimation(Animations.OUT_EXP, 0.5f, VigilancePalette.textActive.toConstraint())
-        }
     }
 
     fun deselect() {
         isSelected = false
         text.animate {
             setColorAnimation(Animations.OUT_EXP, 0.5f, VigilancePalette.text.toConstraint())
+        }
+    }
+
+    fun markSelected() {
+        isSelected = true
+        text.animate {
+            setColorAnimation(Animations.OUT_EXP, 0.5f, VigilancePalette.textActive.toConstraint())
         }
     }
 }

--- a/src/main/kotlin/gg/essential/vigilance/gui/SettingsGui.kt
+++ b/src/main/kotlin/gg/essential/vigilance/gui/SettingsGui.kt
@@ -184,7 +184,16 @@ class SettingsGui(
         newCategory.scrollToTop()
         currentCategory = newCategory
 
-        sidebarScroller.childrenOfType<CategoryLabel>().firstOrNull { it.isSelected }?.deselect()
+        val labels = sidebarScroller.childrenOfType<CategoryLabel>()
+
+        labels
+            .firstOrNull { it.isSelected }
+            ?.deselect()
+
+        // We compare names because the `items` field could technically be the same but the `Category` could be a different instance.
+        labels
+            .firstOrNull { it.category.name == category.name }
+            ?.markSelected()
     }
 
     override fun updateGuiScale() {


### PR DESCRIPTION
When we called `selectCategory()` before this PR, the labels on the left-hand side of the screen did not get updated correctly. The de-selection was performed but the selection was not visible.

Now, when you `selectCategory()` the selection is visible, as well as the de-selection like before.

Since `selectCategory()` is public API, I feel like this is an important change to make :^)