### PR TITLE
AbstractTextInput: Hard-code isAllowedCharacter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.5.10"
 jetbrains-annotations = "23.0.0"
-elementa = "507"
+elementa = "638"
 nightconfig = "3.6.0"
 
 [libraries]

--- a/src/main/kotlin/gg/essential/vigilance/gui/common/input/AbstractTextInput.kt
+++ b/src/main/kotlin/gg/essential/vigilance/gui/common/input/AbstractTextInput.kt
@@ -112,7 +112,7 @@ internal abstract class AbstractTextInput(
                 val operationToRedo = redoStack.pop()
                 operationToRedo.redo()
                 undoStack.push(operationToRedo)
-            } else if (platform.isAllowedInChat(typedChar)) { // Most of the ASCII characters
+            } else if (isAllowedCharacter(typedChar)) { // Most of the ASCII characters
                 commitTextAddition(typedChar.toString())
             } else if (keyCode == UKeyboard.KEY_LEFT) {
                 val holdingShift = UKeyboard.isShiftKeyDown()
@@ -1004,6 +1004,13 @@ internal abstract class AbstractTextInput(
         override fun undo() {
             addTextOperation.undo()
             removeTextOperation.undo()
+        }
+    }
+
+    private companion object {
+        // Mirroring ChatAllowedCharacters.isAllowedCharacter
+        private fun isAllowedCharacter(chr: Char): Boolean {
+            return chr.code != 167 && chr >= ' ' && chr.code != 127
         }
     }
 }

--- a/src/main/kotlin/gg/essential/vigilance/impl/Platform.kt
+++ b/src/main/kotlin/gg/essential/vigilance/impl/Platform.kt
@@ -8,8 +8,6 @@ interface Platform {
 
     fun i18n(key: String): String
 
-    fun isAllowedInChat(char: Char): Boolean
-
     @ApiStatus.Internal
     companion object {
         internal val platform: Platform =

--- a/versions/src/main/java/gg/essential/vigilance/impl/PlatformImpl.java
+++ b/versions/src/main/java/gg/essential/vigilance/impl/PlatformImpl.java
@@ -1,7 +1,6 @@
 package gg.essential.vigilance.impl;
 
 import net.minecraft.client.resources.I18n;
-import net.minecraft.util.ChatAllowedCharacters;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,10 +12,5 @@ public class PlatformImpl implements Platform {
     @Override
     public String i18n(@NotNull String key) {
         return I18n.format(key);
-    }
-
-    @Override
-    public boolean isAllowedInChat(char c) {
-        return ChatAllowedCharacters.isAllowedCharacter(c);
     }
 }


### PR DESCRIPTION
It shouldn't ever change and this way the same Vigilance build continues to be compatible on 1.20.5+ where the MC method was moved to another class.

See also: https://github.com/EssentialGG/Elementa/pull/138