### PR TITLE
Fix library being incorrectly declared as a `LIBRARY`

### DIFF
--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -74,9 +74,6 @@ tasks.jar {
     exclude("META-INF/mods.toml")
     exclude("mcmod.info")
     exclude("kotlin/**")
-    manifest {
-        attributes(mapOf("FMLModType" to "LIBRARY"))
-    }
 }
 
 tasks.named<Jar>("sourcesJar") {


### PR DESCRIPTION
See [UniversalCraft#73](https://github.com/EssentialGG/UniversalCraft/pull/73)